### PR TITLE
Allow multiple route annontations per function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         {
             "name": "Rich Vigorito",
             "email": "richv@ocp.org"
-        },
+        }
     ],
     "require": {
         "php": ">=5.5.9",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "proai/lumen-annotations",
+    "name": "richvigorito/lumen-annotations",
     "description": "Route and event binding annotations for Laravel Lumen",
     "keywords": ["laravel","lumen","route","routes","router","annotations","event","event binding"],
     "homepage": "http://github.com/proai/lumen-annotations",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "rv/lumen-annotations",
+    "name": "proai/lumen-annotations",
     "description": "Route and event binding annotations for Laravel Lumen",
     "keywords": ["laravel","lumen","route","routes","router","annotations","event","event binding"],
     "homepage": "http://github.com/proai/lumen-annotations",
@@ -20,7 +20,7 @@
     },
     "autoload": {
         "psr-4": {
-            "RV\\Annotations\\": "src/"
+            "ProAI\\Annotations\\": "src/"
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "richvigorito/lumen-annotations",
     "description": "Route and event binding annotations for Laravel Lumen",
     "keywords": ["laravel","lumen","route","routes","router","annotations","event","event binding"],
-    "homepage": "http://github.com/proai/lumen-annotations",
+    "homepage": "http://github.com/richvigorito/lumen-annotations",
     "license": "MIT",
     "authors": [
         {
@@ -21,6 +21,11 @@
     "autoload": {
         "psr-4": {
             "ProAI\\Annotations\\": "src/"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,13 @@
 {
-    "name": "richvigorito/lumen-annotations",
+    "name": "proai/lumen-annotations",
     "description": "Route and event binding annotations for Laravel Lumen",
     "keywords": ["laravel","lumen","route","routes","router","annotations","event","event binding"],
-    "homepage": "http://github.com/richvigorito/lumen-annotations",
+    "homepage": "http://github.com/proai/lumen-annotations",
     "license": "MIT",
     "authors": [
         {
             "name": "Markus J. Wetzel",
             "email": "markuswetzel@gmx.net"
-        },
-        {
-            "name": "Rich Vigorito",
-            "email": "richv@ocp.org"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "proai/lumen-annotations",
+    "name": "richvigorito/lumen-annotations",
     "description": "Route and event binding annotations for Laravel Lumen",
     "keywords": ["laravel","lumen","route","routes","router","annotations","event","event binding"],
     "homepage": "http://github.com/proai/lumen-annotations",
@@ -8,7 +8,11 @@
         {
             "name": "Markus J. Wetzel",
             "email": "markuswetzel@gmx.net"
-        }
+        },
+        {
+            "name": "Rich Vigorito",
+            "email": "richv@ocp.org"
+        },
     ],
     "require": {
         "php": ">=5.5.9",
@@ -16,7 +20,7 @@
     },
     "autoload": {
         "psr-4": {
-            "ProAI\\Annotations\\": "src/"
+            "RV\\Annotations\\": "src/"
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "richvigorito/lumen-annotations",
+    "name": "rv/lumen-annotations",
     "description": "Route and event binding annotations for Laravel Lumen",
     "keywords": ["laravel","lumen","route","routes","router","annotations","event","event binding"],
     "homepage": "http://github.com/proai/lumen-annotations",

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,5 @@
         "psr-4": {
             "ProAI\\Annotations\\": "src/"
         }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.0-dev"
-        }
     }
 }

--- a/src/Console/EventClearCommand.php
+++ b/src/Console/EventClearCommand.php
@@ -53,4 +53,9 @@ class EventClearCommand extends Command
 
         $this->info('Events cleared successfully!');
     }
+  
+    public function handle()
+    {
+      $this->fire();
+    }
 }

--- a/src/Console/EventScanCommand.php
+++ b/src/Console/EventScanCommand.php
@@ -88,4 +88,9 @@ class EventScanCommand extends Command
 
         $this->info('Events registered successfully!');
     }
+
+  public function handle()
+    {
+      $this->fire();
+    }
 }

--- a/src/Console/RouteClearCommand.php
+++ b/src/Console/RouteClearCommand.php
@@ -53,4 +53,10 @@ class RouteClearCommand extends Command
 
         $this->info('Routes cleared successfully!');
     }
+
+     public function handle()
+    {
+      $this->fire();
+    }
+
 }

--- a/src/Console/RouteScanCommand.php
+++ b/src/Console/RouteScanCommand.php
@@ -88,9 +88,10 @@ class RouteScanCommand extends Command
 
         $this->info('Routes registered successfully!');
     }
-    
+
     public function handle()
     {
       $this->fire();
     }
+    
 }

--- a/src/Console/RouteScanCommand.php
+++ b/src/Console/RouteScanCommand.php
@@ -88,4 +88,9 @@ class RouteScanCommand extends Command
 
         $this->info('Routes registered successfully!');
     }
+    
+    public function handle()
+    {
+      $this->fire();
+    }
 }

--- a/src/Filesystem/ClassFinder.php
+++ b/src/Filesystem/ClassFinder.php
@@ -1,0 +1,126 @@
+<?php
+namespace ProAI\Annotations\Filesystem;
+use Symfony\Component\Finder\Finder;
+class ClassFinder
+{
+    /**
+     * Find all the class and interface names in a given directory.
+     *
+     * @param  string  $directory
+     * @return array
+     */
+    public function findClasses($directory)
+    {
+        $classes = [];
+        foreach (Finder::create()->in($directory)->name('*.php') as $file) {
+            $classes[] = $this->findClass($file->getRealPath());
+        }
+        return array_filter($classes);
+    }
+    /**
+     * Extract the class name from the file at the given path.
+     *
+     * @param  string  $path
+     * @return string|null
+     */
+    public function findClass($path)
+    {
+        $namespace = null;
+        $tokens = token_get_all(file_get_contents($path));
+        foreach ($tokens as $key => $token) {
+            if ($this->tokenIsNamespace($token)) {
+                $namespace = $this->getNamespace($key + 2, $tokens);
+            } elseif ($this->tokenIsClassOrInterface($token)) {
+                return ltrim($namespace.'\\'.$this->getClass($key + 2, $tokens), '\\');
+            }
+        }
+    }
+    /**
+     * Find the namespace in the tokens starting at a given key.
+     *
+     * @param  int  $key
+     * @param  array  $tokens
+     * @return string|null
+     */
+    protected function getNamespace($key, array $tokens)
+    {
+        $namespace = null;
+        $tokenCount = count($tokens);
+        for ($i = $key; $i < $tokenCount; $i++) {
+            if ($this->isPartOfNamespace($tokens[$i])) {
+                $namespace .= $tokens[$i][1];
+            } elseif ($tokens[$i] == ';') {
+                return $namespace;
+            }
+        }
+    }
+    /**
+     * Find the class in the tokens starting at a given key.
+     *
+     * @param  int  $key
+     * @param  array  $tokens
+     * @return string|null
+     */
+    protected function getClass($key, array $tokens)
+    {
+        $class = null;
+        $tokenCount = count($tokens);
+        for ($i = $key; $i < $tokenCount; $i++) {
+            if ($this->isPartOfClass($tokens[$i])) {
+                $class .= $tokens[$i][1];
+            } elseif ($this->isWhitespace($tokens[$i])) {
+                return $class;
+            }
+        }
+    }
+    /**
+     * Determine if the given token is a namespace keyword.
+     *
+     * @param  array|string  $token
+     * @return bool
+     */
+    protected function tokenIsNamespace($token)
+    {
+        return is_array($token) && $token[0] == T_NAMESPACE;
+    }
+    /**
+     * Determine if the given token is a class or interface keyword.
+     *
+     * @param  array|string  $token
+     * @return bool
+     */
+    protected function tokenIsClassOrInterface($token)
+    {
+        return is_array($token) && ($token[0] == T_CLASS || $token[0] == T_INTERFACE);
+    }
+    /**
+     * Determine if the given token is part of the namespace.
+     *
+     * @param  array|string  $token
+     * @return bool
+     */
+    protected function isPartOfNamespace($token)
+    {
+        return is_array($token) && ($token[0] == T_STRING || $token[0] == T_NS_SEPARATOR);
+    }
+    /**
+     * Determine if the given token is part of the class.
+     *
+     * @param  array|string  $token
+     * @return bool
+     */
+    protected function isPartOfClass($token)
+    {
+        return is_array($token) && $token[0] == T_STRING;
+    }
+    /**
+     * Determine if the given token is whitespace.
+     *
+     * @param  array|string  $token
+     * @return bool
+     */
+    protected function isWhitespace($token)
+    {
+        return is_array($token) && $token[0] == T_WHITESPACE;
+    }
+}

--- a/src/Metadata/ClassFinder.php
+++ b/src/Metadata/ClassFinder.php
@@ -3,7 +3,7 @@
 namespace ProAI\Annotations\Metadata;
 
 use Illuminate\Console\AppNamespaceDetectorTrait;
-use Illuminate\Filesystem\ClassFinder as FilesystemClassFinder;
+use ProAI\Annotations\Filesystem\ClassFinder as FilesystemClassFinder;
 
 class ClassFinder
 {

--- a/src/Metadata/RouteScanner.php
+++ b/src/Metadata/RouteScanner.php
@@ -76,17 +76,16 @@ class RouteScanner
         $classAnnotations = $this->reader->getClassAnnotations($reflectionClass);
 
         $controllerMetadata = [];
-        $middleware = [];
 
         // find entity parameters and plugins
         foreach ($classAnnotations as $annotation) {
             // controller attributes
             if ($annotation instanceof \ProAI\Annotations\Annotations\Controller) {
                 $prefix = $annotation->prefix;
-                $middleware = $this->addMiddleware($middleware, $annotation->middleware);
+                $middleware = $annotation->middleware;
             }
             if ($annotation instanceof \ProAI\Annotations\Annotations\Middleware) {
-                $middleware = $this->addMiddleware($middleware, $annotation->value);
+                $middleware = $annotation->value;
             }
 
             // resource controller
@@ -107,9 +106,12 @@ class RouteScanner
         
         // find routes
         foreach ($reflectionClass->getMethods() as $reflectionMethod) {
+
             $name = $reflectionMethod->getName();
             $methodAnnotations = $this->reader->getMethodAnnotations($reflectionMethod);
+
             $routeMetadata = [];
+
 
             // controller method is resource route
             if (! empty($resource) && in_array($name, $resource['methods'])) {
@@ -124,8 +126,10 @@ class RouteScanner
             }
 
             // controller method is route
-            if ($route = $this->hasHttpMethodAnnotation($name, $methodAnnotations)) {
-                $routeMetadata = [
+            if ($routes = $this->hasHttpMethodAnnotation($name, $methodAnnotations)) {
+              $routeMetadata = [];
+              foreach($routes  as $route){
+                $routeMetadata[] = [
                     'uri' => $route['uri'],
                     'controller' => $class,
                     'controllerMethod' => $name,
@@ -133,27 +137,39 @@ class RouteScanner
                     'as' => $route['as'],
                     'middleware' => $route['middleware']
                 ];
+              }
             }
 
             // add more route options to route metadata
-            if (! empty($routeMetadata)) {
-                if (! empty($middleware)) {
-                    $routeMetadata['middleware'] = $middleware;
+            if (! empty($routeMetadata)) {  
+                if(!isset($routeMetadata[0])){
+                  $temp =  [];
+                  $temp[] = $routeMetadata;
+                  $routeMetadatas  = $temp;
+                } else {
+                  $routeMetadatas  = $routeMetadata;
                 }
+                $idx = 0;
+                foreach($routeMetadatas as $routeMetadata){
+                  $idx++;
 
-                // add other method annotations
-                foreach ($methodAnnotations as $annotation) {
+                  // add other method annotations
+                  foreach ($methodAnnotations as $annotation) {
                     if ($annotation instanceof \ProAI\Annotations\Annotations\Middleware) {
-                        $middleware = $this->addMiddleware($middleware, $routeMetadata['middleware']);
+                        $routeMetadata['middleware'] = $annotation->value;
                     }
-                }
+                  }
 
-                // add global prefix and middleware
-                if (! empty($prefix)) {
+                  // add global prefix and middleware
+                  if (! empty($prefix)) {
                     $routeMetadata['uri'] = $prefix.'/'.$routeMetadata['uri'];
-                }
+                  }
+                  if (! empty($middleware) && empty($routeMetadata['middleware'])) {
+                    $routeMetadata['middleware'] = $middleware;
+                  }
 
-                $controllerMetadata[$name] = $routeMetadata;
+                  $controllerMetadata[$name.$idx] = $routeMetadata;
+              }
             }
         }
 
@@ -211,74 +227,69 @@ class RouteScanner
      */
     protected function hasHttpMethodAnnotation($name, $methodAnnotations)
     {
+
+        $scrapAnnotation = function ($httpMethod,$annotation){
+          // options
+          $as         = (! empty($annotation->as))          ? $annotation->as : '';
+          $middleware = (! empty($annotation->middleware))  ? $annotation->middleware : '';
+
+          $uri = (empty($annotation->value)) ? str_replace("_", "-", snake_case($name)) : $annotation->value;
+          return [
+                  'uri' => $uri,
+                  'httpMethod' => $httpMethod,
+                  'as' => $as,
+                  'middleware' => $middleware
+          ];
+
+        };
+
+
+        $return = [];
+
         foreach ($methodAnnotations as $annotation) {
             // check for http method annotation
             if ($annotation instanceof \ProAI\Annotations\Annotations\Get) {
                 $httpMethod = 'GET';
-                break;
+                $return[] = $scrapAnnotation($httpMethod,$annotation);
+           //     break;
             }
             if ($annotation instanceof \ProAI\Annotations\Annotations\Post) {
                 $httpMethod = 'POST';
-                break;
+                $return[] = $scrapAnnotation($httpMethod,$annotation);
+                //break;
             }
             if ($annotation instanceof \ProAI\Annotations\Annotations\Options) {
                 $httpMethod = 'OPTIONS';
-                break;
+                $return[] = $scrapAnnotation($httpMethod,$annotation);
+               // break;
             }
             if ($annotation instanceof \ProAI\Annotations\Annotations\Put) {
                 $httpMethod = 'PUT';
-                break;
+                $return[] = $scrapAnnotation($httpMethod,$annotation);
+                //break;
             }
             if ($annotation instanceof \ProAI\Annotations\Annotations\Patch) {
                 $httpMethod = 'PATCH';
-                break;
+                $return[] = $scrapAnnotation($httpMethod,$annotation);
+               // break;
             }
             if ($annotation instanceof \ProAI\Annotations\Annotations\Delete) {
                 $httpMethod = 'DELETE';
-                break;
+                $return[] = $scrapAnnotation($httpMethod,$annotation);
+                //break;
             }
             if ($annotation instanceof \ProAI\Annotations\Annotations\Any) {
                 $httpMethod = 'ANY';
-                break;
+                $return[] = $scrapAnnotation($httpMethod,$annotation);
+                //break;
             }
 
         }
 
-        // http method found
-        if (! empty($httpMethod)) {
-            // options
-            $as = (! empty($annotation->as)) ? $annotation->as : '';
-
-            $uri = (empty($annotation->value)) ? str_replace("_", "-", snake_case($name)) : $annotation->value;
-
-            return [
-                'uri' => $uri,
-                'httpMethod' => $httpMethod,
-                'as' => $as,
-                'middleware' => $this->addMiddleware([], $annotation->middleware)
-            ];
+        if(count($return) > 0){
+          return $return;
+        } else {
+          return false;
         }
-
-        return null;
-    }
-
-    /**
-     * Add middleware
-     *
-     * @param array $middleware
-     * @param array $newMiddleware
-     * @return array
-     */
-    protected function addMiddleware($middleware, $newMiddleware)
-    {
-        if (! empty($newMiddleware)) {
-            $newMiddleware = (is_array($newMiddleware))
-                ? $newMiddleware
-                : [$newMiddleware];
-
-            return array_merge($middleware, $newMiddleware);
-        }
-
-        return $middleware;
     }
 }

--- a/src/Metadata/RouteScanner.php
+++ b/src/Metadata/RouteScanner.php
@@ -153,12 +153,17 @@ class RouteScanner
                 foreach($routeMetadatas as $routeMetadata){
                   $idx++;
 
-                  // add other method annotations
-                  foreach ($methodAnnotations as $annotation) {
-                    if ($annotation instanceof \ProAI\Annotations\Annotations\Middleware) {
-                        $routeMetadata['middleware'] = $annotation->value;
-                    }
+                // add other method annotations
+                foreach ($methodAnnotations as $annotation) {
+                  if ($annotation instanceof \ProAI\Annotations\Annotations\Middleware) {
+                      if (!empty($middleware) && isset($routeMetadata['middleware'])) {
+                          $routeMetadata['middleware'] = [$middleware, $annotation->value];
+                          continue;
+                      }
+
+                      $routeMetadata['middleware'] = $annotation->value;
                   }
+                }
 
                   // add global prefix and middleware
                   if (! empty($prefix)) {

--- a/src/Metadata/RouteScanner.php
+++ b/src/Metadata/RouteScanner.php
@@ -228,7 +228,7 @@ class RouteScanner
     protected function hasHttpMethodAnnotation($name, $methodAnnotations)
     {
 
-        $scrapAnnotation = function ($httpMethod,$annotation){
+        $parseAnnotation = function ($httpMethod,$annotation){
           // options
           $as         = (! empty($annotation->as))          ? $annotation->as : '';
           $middleware = (! empty($annotation->middleware))  ? $annotation->middleware : '';
@@ -250,37 +250,37 @@ class RouteScanner
             // check for http method annotation
             if ($annotation instanceof \ProAI\Annotations\Annotations\Get) {
                 $httpMethod = 'GET';
-                $return[] = $scrapAnnotation($httpMethod,$annotation);
+                $return[] = $parseAnnotation($httpMethod,$annotation);
            //     break;
             }
             if ($annotation instanceof \ProAI\Annotations\Annotations\Post) {
                 $httpMethod = 'POST';
-                $return[] = $scrapAnnotation($httpMethod,$annotation);
+                $return[] = $parseAnnotation($httpMethod,$annotation);
                 //break;
             }
             if ($annotation instanceof \ProAI\Annotations\Annotations\Options) {
                 $httpMethod = 'OPTIONS';
-                $return[] = $scrapAnnotation($httpMethod,$annotation);
+                $return[] = $parseAnnotation($httpMethod,$annotation);
                // break;
             }
             if ($annotation instanceof \ProAI\Annotations\Annotations\Put) {
                 $httpMethod = 'PUT';
-                $return[] = $scrapAnnotation($httpMethod,$annotation);
+                $return[] = $parseAnnotation($httpMethod,$annotation);
                 //break;
             }
             if ($annotation instanceof \ProAI\Annotations\Annotations\Patch) {
                 $httpMethod = 'PATCH';
-                $return[] = $scrapAnnotation($httpMethod,$annotation);
+                $return[] = $parseAnnotation($httpMethod,$annotation);
                // break;
             }
             if ($annotation instanceof \ProAI\Annotations\Annotations\Delete) {
                 $httpMethod = 'DELETE';
-                $return[] = $scrapAnnotation($httpMethod,$annotation);
+                $return[] = $parseAnnotation($httpMethod,$annotation);
                 //break;
             }
             if ($annotation instanceof \ProAI\Annotations\Annotations\Any) {
                 $httpMethod = 'ANY';
-                $return[] = $scrapAnnotation($httpMethod,$annotation);
+                $return[] = $parseAnnotation($httpMethod,$annotation);
                 //break;
             }
 

--- a/src/Providers/MetadataServiceProvider.php
+++ b/src/Providers/MetadataServiceProvider.php
@@ -4,7 +4,7 @@ namespace ProAI\Annotations\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use ProAI\Annotations\Metadata\ClassFinder;
-use Illuminate\Filesystem\ClassFinder as FilesystemClassFinder;
+use ProAI\Annotations\Filesystem\ClassFinder as FilesystemClassFinder;
 use ProAI\Annotations\Metadata\AnnotationLoader;
 use Doctrine\Common\Annotations\AnnotationReader;
 

--- a/src/Routing/Generator.php
+++ b/src/Routing/Generator.php
@@ -84,6 +84,8 @@ class Generator
     public function generateRoutes($metadata)
     {
         $contents = '<?php' . PHP_EOL;
+        $contents = '$app = app(); ' . PHP_EOL;
+        $contents = '$router = $app->router; ' . PHP_EOL;
 
         $routes = [];
 
@@ -111,7 +113,7 @@ class Generator
                 // uses option
                 $options[] = "'uses' => '".$routeMetadata['controller']."@".$routeMetadata['controllerMethod']."'";
 
-                $contents .= "\$app->".strtolower($routeMetadata['httpMethod'])."('".$routeMetadata['uri']."', [".implode(", ", $options)."]);" . PHP_EOL;
+                $contents .= "\$router>".strtolower($routeMetadata['httpMethod'])."('".$routeMetadata['uri']."', [".implode(", ", $options)."]);" . PHP_EOL;
             }
         }
 

--- a/src/Routing/Generator.php
+++ b/src/Routing/Generator.php
@@ -84,8 +84,8 @@ class Generator
     public function generateRoutes($metadata)
     {
         $contents = '<?php' . PHP_EOL;
-        $contents = '$app = app(); ' . PHP_EOL;
-        $contents = '$router = $app->router; ' . PHP_EOL;
+        $contents .= '$app = app(); ' . PHP_EOL;
+        $contents .= '$router = $app->router; ' . PHP_EOL;
 
         $routes = [];
 
@@ -113,7 +113,7 @@ class Generator
                 // uses option
                 $options[] = "'uses' => '".$routeMetadata['controller']."@".$routeMetadata['controllerMethod']."'";
 
-                $contents .= "\$router>".strtolower($routeMetadata['httpMethod'])."('".$routeMetadata['uri']."', [".implode(", ", $options)."]);" . PHP_EOL;
+                $contents .= "\$router"."->".strtolower($routeMetadata['httpMethod'])."('".$routeMetadata['uri']."', [".implode(", ", $options)."]);" . PHP_EOL;
             }
         }
 

--- a/src/Routing/Generator.php
+++ b/src/Routing/Generator.php
@@ -100,11 +100,10 @@ class Generator
 
                 // middleware option
                 if (! empty($routeMetadata['middleware'])) {
-                    $middleware = implode("', '",$routeMetadata['middleware']);
-                    if (count($routeMetadata['middleware']) > 1) {
-                        $middleware = "['".$middleware."']";
+                    if (is_array($routeMetadata['middleware'])) {
+                        $middleware = "['".implode("', '",$routeMetadata['middleware'])."']";
                     } else {
-                        $middleware = "'".$middleware."'";
+                        $middleware = "'".$routeMetadata['middleware']."'";
                     }
                     $options[] = "'middleware' => ".$middleware;
                 }


### PR DESCRIPTION
This change allows for the ability to create multiple method annotations for routes per function. 

Example:

/*
@get('/country/{country_iso}/users
@get('/country/{country_iso}/state/{state_iso}/users
*/
function getUsersByLocation($country_iso,$state_iso = null){}